### PR TITLE
Add bash to development tools

### DIFF
--- a/tasks/development-tools.yml
+++ b/tasks/development-tools.yml
@@ -85,6 +85,16 @@
     - developer-tools
     - install
 
+- name: Install bash
+  community.general.homebrew:
+    name: bash
+    state: present
+  tags:
+    - bash
+    - shell
+    - developer-tools
+    - install
+
 - name: Install libpq
   community.general.homebrew:
     name: libpq


### PR DESCRIPTION
Add bash in order to be able to use bashly which is a powerful 
framework to build shell scripts and their ouptut is bash