### PR TITLE
Remove kustomize from developer tools

### DIFF
--- a/tasks/development-tools.yml
+++ b/tasks/development-tools.yml
@@ -85,17 +85,6 @@
     - developer-tools
     - install
 
-- name: Install kustomize
-  community.general.homebrew:
-    name: kustomize
-    state: removed
-  tags:
-    - kubernetes
-    - cli
-    - kustomize
-    - developer-tools
-    - install
-
 - name: Install bash
   community.general.homebrew:
     name: bash


### PR DESCRIPTION
Kustomize is installed though asdf-vm so their manual 
installation is removed from the developer-tools yaml file