### PR TITLE
Add zellij a terminal multiplexor

### DIFF
--- a/tasks/terminal.yml
+++ b/tasks/terminal.yml
@@ -68,6 +68,16 @@
     - vim
     - tool
 
+- name: Install zellij
+  community.general.homebrew:
+    name: zellij
+    state: present
+  tags:
+    - zellij
+    - terminal
+    - install
+    - terminal-multiplexer
+
 - name: Install tmux
   community.general.homebrew:
     name: tmux


### PR DESCRIPTION
This terminal multiplexor allows developers to have 
layouts with things that are going to be loaded by default