### PR TITLE
Use orbstack instead of docker desktop

### DIFF
--- a/tasks/development-tools.yml
+++ b/tasks/development-tools.yml
@@ -368,7 +368,7 @@
 - name: Install docker
   community.general.homebrew_cask:
     name: docker
-    state: present
+    state: absent
   tags:
     - developer-tools
     - install


### PR DESCRIPTION
Docker desktop is slower and it consume more resources than orbstack so us it instead of docker desktop